### PR TITLE
Fix code block copy js

### DIFF
--- a/static/js/copy-to-clipboard.js
+++ b/static/js/copy-to-clipboard.js
@@ -34,7 +34,7 @@ document.querySelectorAll("div.highlight pre").forEach((snippet) => {
 // Add copy to clipboard functionality
 const clipboard = new ClipboardJS(".codecopy-btn", {
   target: (trigger) => {
-    return trigger.parentNode;
+    return trigger.parentNode.querySelector("code");
   },
 });
 


### PR DESCRIPTION
Narrow down the scope of copy targets
Only copy the content within `<code>`